### PR TITLE
TECH-4677: TECH-4456 (more logging and rescue) plus Listen issue #481

### DIFF
--- a/lib/listen/adapter/base.rb
+++ b/lib/listen/adapter/base.rb
@@ -87,10 +87,7 @@ module Listen
 
       def stop
         _stop
-      end
-
-      def self.usable?
-        const_get('OS_REGEXP') =~ RbConfig::CONFIG['target_os']
+        config.queue.close # this causes queue.pop to return `nil` to the front-end
       end
 
       private
@@ -130,6 +127,10 @@ module Listen
       end
 
       class << self
+        def usable?
+          const_get('OS_REGEXP') =~ RbConfig::CONFIG['target_os']
+        end
+
         private
 
         def _log(*args, &block)

--- a/lib/listen/event/config.rb
+++ b/lib/listen/event/config.rb
@@ -19,8 +19,8 @@ module Listen
         @block = block
       end
 
-      def sleep(*args)
-        Kernel.sleep(*args)
+      def sleep(seconds)
+        Kernel.sleep(seconds)
       end
 
       def call(*args)

--- a/lib/listen/event/config.rb
+++ b/lib/listen/event/config.rb
@@ -1,6 +1,10 @@
 module Listen
   module Event
     class Config
+      attr_reader :listener
+      attr_reader :event_queue
+      attr_reader :min_delay_between_events
+
       def initialize(
         listener,
         event_queue,
@@ -27,8 +31,6 @@ module Listen
         Time.now.to_f
       end
 
-      attr_reader :event_queue
-
       def callable?
         @block
       end
@@ -36,20 +38,6 @@ module Listen
       def optimize_changes(changes)
         @queue_optimizer.smoosh_changes(changes)
       end
-
-      attr_reader :min_delay_between_events
-
-      def stopped?
-        listener.state == :stopped
-      end
-
-      def paused?
-        listener.state == :paused
-      end
-
-      private
-
-      attr_reader :listener
     end
   end
 end

--- a/lib/listen/event/loop.rb
+++ b/lib/listen/event/loop.rb
@@ -33,7 +33,7 @@ module Listen
         @state = :starting
         q = ::Queue.new
         @wait_thread = Internals::ThreadPool.add do
-          _wait_for_changes(q)
+          _process_changes(q)
         end
 
         Listen::Logger.debug('Waiting for processing to start...')
@@ -67,11 +67,12 @@ module Listen
 
       private
 
-      def _wait_for_changes(ready_queue)
+      def _process_changes(ready_queue)
         processor = Event::Processor.new(@config, @reasons)
 
         _wait_until_resumed(ready_queue)
         processor.loop_for(@config.min_delay_between_events)
+
       rescue StandardError => ex
         _nice_error(ex)
       end

--- a/lib/listen/event/loop.rb
+++ b/lib/listen/event/loop.rb
@@ -14,32 +14,26 @@ module Listen
       def initialize(config)
         @config = config
         @wait_thread = nil
-        @state = :paused
+        @state = :pre_start # ... :starting, :started, :stopped
         @reasons = ::Queue.new
       end
 
       def wakeup_on_event
-        return if stopped?
-        return unless processing?
-        return unless wait_thread.alive?
-        _wakeup(:event)
+        if started? && @wait_thread.alive?
+          _wakeup(:event)
+        end
       end
 
-      def paused?
-        wait_thread && state == :paused
+      def started?
+        @state == :started
       end
 
-      def processing?
-        return false if stopped?
-        return false if paused?
-        state == :processing
-      end
-
-      def setup
+      def start
         # TODO: use a Fiber instead?
+        @state = :starting
         q = ::Queue.new
         @wait_thread = Internals::ThreadPool.add do
-          _wait_for_changes(q, config)
+          _wait_for_changes(q)
         end
 
         Listen::Logger.debug('Waiting for processing to start...')
@@ -47,8 +41,8 @@ module Listen
       end
 
       def resume
-        fail Error::NotStarted if stopped?
-        return unless wait_thread
+        fail Error::NotStarted if @state == :pre_start
+        return unless @wait_thread
         _wakeup(:resume)
       end
 
@@ -58,30 +52,26 @@ module Listen
       end
 
       def teardown
-        return unless wait_thread
-        if wait_thread.alive?
+        return if stopped?
+        if @wait_thread.alive?
           _wakeup(:teardown)
-          wait_thread.join
+          @wait_thread.join
         end
         @wait_thread = nil
+        @state = :stopped
       end
 
       def stopped?
-        !wait_thread
+        @state == :stopped
       end
 
       private
 
-      attr_reader :config
-      attr_reader :wait_thread
-
-      attr_accessor :state
-
-      def _wait_for_changes(ready_queue, config)
-        processor = Event::Processor.new(config, @reasons)
+      def _wait_for_changes(ready_queue)
+        processor = Event::Processor.new(@config, @reasons)
 
         _wait_until_resumed(ready_queue)
-        processor.loop_for(config.min_delay_between_events)
+        processor.loop_for(@config.min_delay_between_events)
       rescue StandardError => ex
         _nice_error(ex)
       end
@@ -91,10 +81,9 @@ module Listen
       end
 
       def _wait_until_resumed(ready_queue)
-        self.state = :paused
         ready_queue << :ready
         sleep
-        self.state = :processing
+        @state = :started
       end
 
       def _nice_error(ex)
@@ -110,7 +99,7 @@ module Listen
 
       def _wakeup(reason)
         @reasons << reason
-        wait_thread.wakeup
+        @wait_thread.wakeup
       end
     end
   end

--- a/lib/listen/event/loop.rb
+++ b/lib/listen/event/loop.rb
@@ -7,19 +7,21 @@ module Listen
   module Event
     class Loop
       class Error < RuntimeError
-        class NotStarted < Error
-        end
+        class ThreadFailedToStart < Error; end
+        class AlreadyStarted < Error; end
       end
 
       def initialize(config)
         @config = config
         @wait_thread = nil
+        @mutex = ::Mutex.new
+        @state_changed = ::ConditionVariable.new
         @state = :pre_start # ... :starting, :started, :stopped
         @reasons = ::Queue.new
       end
 
       def wakeup_on_event
-        if started? && @wait_thread.alive?
+        if started? && @wait_thread&.alive?
           _wakeup(:event)
         end
       end
@@ -28,22 +30,22 @@ module Listen
         @state == :started
       end
 
+      MAX_STARTUP_SECONDS = 5.0
+
       def start
-        # TODO: use a Fiber instead?
-        @state = :starting
-        q = ::Queue.new
-        @wait_thread = Internals::ThreadPool.add do
-          _process_changes(q)
+        _transition!(:starting) do
+          @state == :pre_start or raise Error::AlreadyStarted
         end
 
-        Listen::Logger.debug('Waiting for processing to start...')
-        Timeout.timeout(5) { q.pop }
-      end
+        @wait_thread = Internals::ThreadPool.add do
+          _process_changes
+        end
 
-      def resume
-        fail Error::NotStarted if @state == :pre_start
-        return unless @wait_thread
-        _wakeup(:resume)
+        Listen::Logger.debug("Waiting for processing to start...")
+
+        _wait_for_state(:started, MAX_STARTUP_SECONDS) or raise Error::ThreadFailedToStart, "thread didn't start in #{MAX_STARTUP_SECONDS} seconds (in state: #{@state.inspect})"
+
+        Listen::Logger.debug('Processing started.')
       end
 
       def pause
@@ -53,12 +55,13 @@ module Listen
 
       def teardown
         return if stopped?
+        _transition!(:stopped)
+
         if @wait_thread.alive?
           _wakeup(:teardown)
           @wait_thread.join
         end
         @wait_thread = nil
-        @state = :stopped
       end
 
       def stopped?
@@ -67,24 +70,35 @@ module Listen
 
       private
 
-      def _process_changes(ready_queue)
+      def _transition!(new_state)
+        @mutex.synchronize do
+          yield if block_given?
+          @state = new_state
+          @state_changed.signal
+        end
+      end
+
+      # checks for the given state
+      # if not in it, waits for a state change (up to timeout_seconds--`nil` means infinite)
+      # returns truthy iff the transition to the desired state has occurred
+      def _wait_for_state(state, timeout_seconds = nil)
+        @mutex.synchronize do
+          if @state != state
+            @state_changed.wait(@mutex, timeout_seconds)
+          end
+          @state == state
+        end
+      end
+
+      def _process_changes
         processor = Event::Processor.new(@config, @reasons)
 
-        _wait_until_resumed(ready_queue)
+        _transition!(:started)
+
         processor.loop_for(@config.min_delay_between_events)
 
       rescue StandardError => ex
         _nice_error(ex)
-      end
-
-      def _sleep(*args)
-        Kernel.sleep(*args)
-      end
-
-      def _wait_until_resumed(ready_queue)
-        ready_queue << :ready
-        sleep
-        @state = :started
       end
 
       def _nice_error(ex)

--- a/lib/listen/event/loop.rb
+++ b/lib/listen/event/loop.rb
@@ -58,7 +58,6 @@ module Listen
         _transition!(:stopped)
 
         if @wait_thread.alive?
-          _wakeup(:teardown)
           @wait_thread.join
         end
         @wait_thread = nil

--- a/lib/listen/event/loop.rb
+++ b/lib/listen/event/loop.rb
@@ -59,7 +59,7 @@ module Listen
         # fail NotImplementedError
       end
 
-      def teardown
+      def stop
         return if stopped?
         transition! :stopped
 

--- a/lib/listen/event/loop.rb
+++ b/lib/listen/event/loop.rb
@@ -6,18 +6,24 @@ require 'listen/event/processor'
 module Listen
   module Event
     class Loop
+      include Listen::FSM
+
       class Error < RuntimeError
         class ThreadFailedToStart < Error; end
         class AlreadyStarted < Error; end
       end
 
+      start_state :pre_start
+      state :pre_start
+      state :starting
+      state :started
+      state :stopped
+
       def initialize(config)
         @config = config
         @wait_thread = nil
-        @mutex = ::Mutex.new
-        @state_changed = ::ConditionVariable.new
-        @state = :pre_start # ... :starting, :started, :stopped
         @reasons = ::Queue.new
+        super()
       end
 
       def wakeup_on_event
@@ -27,14 +33,14 @@ module Listen
       end
 
       def started?
-        @state == :started
+        state == :started
       end
 
       MAX_STARTUP_SECONDS = 5.0
 
       def start
-        _transition!(:starting) do
-          @state == :pre_start or raise Error::AlreadyStarted
+        transition! :starting do
+          state == :pre_start or raise Error::AlreadyStarted
         end
 
         @wait_thread = Internals::ThreadPool.add do
@@ -43,7 +49,7 @@ module Listen
 
         Listen::Logger.debug("Waiting for processing to start...")
 
-        _wait_for_state(:started, MAX_STARTUP_SECONDS) or raise Error::ThreadFailedToStart, "thread didn't start in #{MAX_STARTUP_SECONDS} seconds (in state: #{@state.inspect})"
+        wait_for_state(:started, MAX_STARTUP_SECONDS) or raise Error::ThreadFailedToStart, "thread didn't start in #{MAX_STARTUP_SECONDS} seconds (in state: #{state.inspect})"
 
         Listen::Logger.debug('Processing started.')
       end
@@ -55,7 +61,7 @@ module Listen
 
       def teardown
         return if stopped?
-        _transition!(:stopped)
+        transition! :stopped
 
         if @wait_thread.alive?
           @wait_thread.join
@@ -64,35 +70,15 @@ module Listen
       end
 
       def stopped?
-        @state == :stopped
+        state == :stopped
       end
 
       private
 
-      def _transition!(new_state)
-        @mutex.synchronize do
-          yield if block_given?
-          @state = new_state
-          @state_changed.signal
-        end
-      end
-
-      # checks for the given state
-      # if not in it, waits for a state change (up to timeout_seconds--`nil` means infinite)
-      # returns truthy iff the transition to the desired state has occurred
-      def _wait_for_state(state, timeout_seconds = nil)
-        @mutex.synchronize do
-          if @state != state
-            @state_changed.wait(@mutex, timeout_seconds)
-          end
-          @state == state
-        end
-      end
-
       def _process_changes
         processor = Event::Processor.new(@config, @reasons)
 
-        _transition!(:started)
+        transition! :started
 
         processor.loop_for(@config.min_delay_between_events)
 

--- a/lib/listen/event/processor.rb
+++ b/lib/listen/event/processor.rb
@@ -40,7 +40,7 @@ module Listen
 
           # give events a bit of time to accumulate so they can be
           # compressed/optimized
-          _sleep(:waiting_until_latency, diff)
+          _sleep(diff)
         end
       end
 
@@ -55,9 +55,9 @@ module Listen
         raise Stopped
       end
 
-      def _sleep(_local_reason, *args)
+      def _sleep(seconds)
         _check_stopped
-        sleep_duration = config.sleep(*args)
+        config.sleep(seconds)
         _check_stopped
 
         _flush_wakeup_reasons do |reason|
@@ -65,8 +65,6 @@ module Listen
             _remember_time_of_first_unprocessed_event
           end
         end
-
-        sleep_duration
       end
 
       def _remember_time_of_first_unprocessed_event

--- a/lib/listen/event/processor.rb
+++ b/lib/listen/event/processor.rb
@@ -3,6 +3,7 @@ module Listen
     class Processor
       def initialize(config, reasons)
         @config = config
+        @listener = config.listener
         @reasons = reasons
         _reset_no_unprocessed_events
       end
@@ -45,11 +46,11 @@ module Listen
 
       def _wait_until_no_longer_paused
         # TODO: may not be a good idea?
-        _sleep(:waiting_for_unpause) while config.paused?
+        _sleep(:waiting_for_unpause) while @listener.paused?
       end
 
       def _check_stopped
-        return unless config.stopped?
+        return unless @listener.stopped?
 
         _flush_wakeup_reasons
         raise Stopped
@@ -61,7 +62,7 @@ module Listen
         _check_stopped
 
         _flush_wakeup_reasons do |reason|
-          if reason == :event && !config.paused?
+          if reason == :event && !@listener.paused?
             _remember_time_of_first_unprocessed_event
           end
         end

--- a/lib/listen/event/processor.rb
+++ b/lib/listen/event/processor.rb
@@ -45,8 +45,7 @@ module Listen
       end
 
       def _wait_until_no_longer_paused
-        # TODO: may not be a good idea?
-        _sleep(:waiting_for_unpause) while @listener.paused?
+        @listener.wait_for_state(:processing_events, :stopped)
       end
 
       def _check_stopped

--- a/lib/listen/event/processor.rb
+++ b/lib/listen/event/processor.rb
@@ -45,7 +45,7 @@ module Listen
       end
 
       def _wait_until_no_longer_paused
-        @listener.wait_for_state(:processing_events, :stopped)
+        @listener.wait_for_state(*(Listener.states.keys - [:paused]))
       end
 
       def _check_stopped

--- a/lib/listen/event/queue.rb
+++ b/lib/listen/event/queue.rb
@@ -18,8 +18,8 @@ module Listen
       end
 
       def initialize(config, &block)
+        block and raise ArgumentError, "&block no longer needed"
         @event_queue = ::Queue.new
-        @block = block
         @config = config
       end
 
@@ -31,17 +31,15 @@ module Listen
 
         dir = _safe_relative_from_cwd(dir)
         event_queue.public_send(:<<, [type, change, dir, path, options])
-
-        block.call(args) if block
       end
 
       delegate empty?: :event_queue
       delegate pop: :event_queue
+      delegate close: :event_queue
 
       private
 
       attr_reader :event_queue
-      attr_reader :block
       attr_reader :config
 
       def _safe_relative_from_cwd(dir)

--- a/lib/listen/event/queue.rb
+++ b/lib/listen/event/queue.rb
@@ -17,8 +17,7 @@ module Listen
         end
       end
 
-      def initialize(config, &block)
-        block and raise ArgumentError, "&block no longer needed"
+      def initialize(config)
         @event_queue = ::Queue.new
         @config = config
       end

--- a/lib/listen/fsm.rb
+++ b/lib/listen/fsm.rb
@@ -68,12 +68,12 @@ module Listen
     # checks for one of the given states
     # if not already, waits for a state change (up to timeout seconds--`nil` means infinite)
     # returns truthy iff the transition to one of the desired state has occurred
-    def wait_for_state(*states, timeout: nil)
+    def wait_for_state(*wait_for_states, timeout: nil)
       @mutex.synchronize do
-        if !states.include?(@state)
+        if !wait_for_states.include?(@state)
           @state_changed.wait(@mutex, timeout)
         end
-        states.include?(@state)
+        wait_for_states.include?(@state)
       end
     end
 

--- a/lib/listen/fsm.rb
+++ b/lib/listen/fsm.rb
@@ -62,7 +62,7 @@ module Listen
       @mutex.synchronize do
         yield if block_given?
         @state = new_state_name
-        @state_changed.signal
+        @state_changed.broadcast
       end
     end
 

--- a/lib/listen/listener.rb
+++ b/lib/listen/listener.rb
@@ -73,7 +73,7 @@ module Listen
     end
 
     state :processing_events, to: [:paused, :stopped] do
-      processor.resume
+      # nothing to do--already started
     end
 
     state :paused, to: [:processing_events, :stopped] do

--- a/lib/listen/listener.rb
+++ b/lib/listen/listener.rb
@@ -38,7 +38,7 @@ module Listen
       @config = Config.new(options)
 
       eq_config = Event::Queue::Config.new(@config.relative?)
-      queue = Event::Queue.new(eq_config) { @processor.wakeup_on_event }
+      queue = Event::Queue.new(eq_config)
 
       silencer = Silencer.new
       rules = @config.silencer_rules

--- a/lib/listen/listener.rb
+++ b/lib/listen/listener.rb
@@ -60,7 +60,7 @@ module Listen
       super() # FSM
     end
 
-    default_state :initializing
+    start_state :initializing
 
     state :initializing, to: [:backend_started, :stopped]
 

--- a/lib/listen/listener.rb
+++ b/lib/listen/listener.rb
@@ -69,7 +69,7 @@ module Listen
     end
 
     state :frontend_ready, to: [:processing_events, :stopped] do
-      processor.setup
+      processor.start
     end
 
     state :processing_events, to: [:paused, :stopped] do

--- a/lib/listen/listener.rb
+++ b/lib/listen/listener.rb
@@ -77,8 +77,8 @@ module Listen
     end
 
     state :stopped, to: [:backend_started] do
-      backend.stop # should be before processor.teardown to halt events ASAP
-      processor.teardown
+      backend.stop # should be before processor.stop to halt events ASAP
+      processor.stop
     end
 
     # Starts processing events and starts adapters

--- a/lib/listen/listener.rb
+++ b/lib/listen/listener.rb
@@ -114,6 +114,10 @@ module Listen
       state == :paused
     end
 
+    def stopped?
+      state == :stopped
+    end
+
     def ignore(regexps)
       @silencer_controller.append_ignores(regexps)
     end

--- a/lib/listen/version.rb
+++ b/lib/listen/version.rb
@@ -1,3 +1,3 @@
 module Listen
-  VERSION = '3.2.1.invoca.2'.freeze
+  VERSION = '3.2.1.invoca.3'.freeze
 end

--- a/listen.gemspec
+++ b/listen.gemspec
@@ -1,5 +1,5 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'listen/version'
 

--- a/spec/lib/listen/event/loop_spec.rb
+++ b/spec/lib/listen/event/loop_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe Listen::Event::Loop do
   let(:blocks) do
     {
       thread_block: proc { fail 'thread block stub called' },
-      timer_block: proc { fail 'thread block stub called' }
     }
   end
 
@@ -38,10 +37,6 @@ RSpec.describe Listen::Event::Loop do
       thread
     end
 
-    allow(Timeout).to receive(:timeout) do |*_args, &block|
-      blocks[:timer_block] = block
-    end
-
     allow(Kernel).to receive(:sleep) do |*args|
       fail "stub called: sleep(#{args.map(&:inspect) * ','})"
     end
@@ -53,32 +48,7 @@ RSpec.describe Listen::Event::Loop do
     end
   end
 
-  describe '#setup' do
-    before do
-      allow(thread).to receive(:wakeup)
-      allow(thread).to receive(:alive?).and_return(true)
-      allow(config).to receive(:min_delay_between_events).and_return(1.234)
-      allow(ready).to receive(:<<).with(:ready)
-    end
-
-    it 'sets up the thread in a resumable state' do
-      subject.start
-
-      expect(subject).to receive(:sleep).with(no_args)
-      allow(processor).to receive(:loop_for).with(1.234)
-
-      blocks[:thread_block].call
-    end
-  end
-
   context 'when stopped' do
-    context 'when resume is called' do
-      it 'fails' do
-        expect { subject.resume }.
-          to raise_error(Listen::Event::Loop::Error::NotStarted)
-      end
-    end
-
     context 'when wakeup_on_event is called' do
       it 'does nothing' do
         subject.wakeup_on_event
@@ -86,28 +56,25 @@ RSpec.describe Listen::Event::Loop do
     end
   end
 
-  context 'when resumed' do
+  describe '#start' do
     before do
-      subject.start
-
-      allow(thread).to receive(:wakeup) do
-        allow(subject).to receive(:sleep).with(no_args)
-        allow(processor).to receive(:loop_for).with(1.234)
-        allow(ready).to receive(:<<).with(:ready)
-        blocks[:thread_block].call
+      expect(Listen::Internals::ThreadPool).to receive(:add) do |*_, &block|
+        block.call
+        thread
       end
 
-      allow(reasons).to receive(:<<).with(:resume)
-      subject.resume
+      expect(processor).to receive(:loop_for).with(1.234)
+
+      subject.start
     end
 
     it 'is started' do
       expect(subject).to be_started
     end
 
-    context 'when resume is called again' do
-      it 'does nothing' do
-        subject.resume
+    context 'when start is called again' do
+      it 'raises AlreadyStarted' do
+        expect { subject.start }.to raise_exception(Listen::Event::Loop::Error::AlreadyStarted)
       end
     end
 
@@ -122,10 +89,12 @@ RSpec.describe Listen::Event::Loop do
 
         it 'wakes up the thread' do
           expect(thread).to receive(:wakeup)
+          expect(subject.instance_variable_get(:@state)).to eq(:started)
           subject.wakeup_on_event
         end
 
         it 'sets the reason for waking up' do
+          expect(thread).to receive(:wakeup)
           expect(reasons).to receive(:<<).with(:event)
           subject.wakeup_on_event
         end
@@ -144,47 +113,26 @@ RSpec.describe Listen::Event::Loop do
     end
   end
 
-  context 'when set up / paused' do
+  context 'when set up / started' do
     before do
       allow(thread).to receive(:alive?).and_return(true)
       allow(config).to receive(:min_delay_between_events).and_return(1.234)
 
-      allow(thread).to receive(:wakeup)
+      allow(processor).to receive(:loop_for).with(1.234)
+
+      expect(Listen::Internals::ThreadPool).to receive(:add) do |*_, &block|
+        block.call
+        thread
+      end
 
       subject.start
-
-      allow(subject).to receive(:sleep).with(no_args) do
-        allow(processor).to receive(:loop_for).with(1.234)
-        blocks[:timer_block].call
-      end
-
-      allow(ready).to receive(:<<).with(:ready)
-      allow(ready).to receive(:pop)
-
-      blocks[:thread_block].call
-    end
-
-    describe '#resume' do
-      before do
-        allow(reasons).to receive(:<<)
-        allow(thread).to receive(:wakeup)
-      end
-
-      it 'resumes the thread' do
-        expect(thread).to receive(:wakeup)
-        subject.resume
-      end
-
-      it 'sets the reason for waking up' do
-        expect(reasons).to receive(:<<).with(:resume)
-        subject.resume
-      end
     end
 
     describe '#teardown' do
       before do
         allow(reasons).to receive(:<<)
         allow(thread).to receive(:join)
+        expect(thread).to receive(:wakeup)
       end
 
       it 'frees the thread' do

--- a/spec/lib/listen/event/loop_spec.rb
+++ b/spec/lib/listen/event/loop_spec.rb
@@ -128,22 +128,22 @@ RSpec.describe Listen::Event::Loop do
       subject.start
     end
 
-    describe '#teardown' do
+    describe '#stop' do
       before do
         allow(thread).to receive(:join)
       end
 
       it 'frees the thread' do
-        subject.teardown
+        subject.stop
       end
 
       it 'waits for the thread to finish' do
         expect(thread).to receive(:join)
-        subject.teardown
+        subject.stop
       end
 
       it 'sets the reason for waking up' do
-        subject.teardown
+        subject.stop
       end
     end
   end

--- a/spec/lib/listen/event/loop_spec.rb
+++ b/spec/lib/listen/event/loop_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Listen::Event::Loop do
     end
 
     it 'sets up the thread in a resumable state' do
-      subject.setup
+      subject.start
 
       expect(subject).to receive(:sleep).with(no_args)
       allow(processor).to receive(:loop_for).with(1.234)
@@ -88,7 +88,7 @@ RSpec.describe Listen::Event::Loop do
 
   context 'when resumed' do
     before do
-      subject.setup
+      subject.start
 
       allow(thread).to receive(:wakeup) do
         allow(subject).to receive(:sleep).with(no_args)
@@ -101,8 +101,8 @@ RSpec.describe Listen::Event::Loop do
       subject.resume
     end
 
-    it 'is not paused' do
-      expect(subject).to_not be_paused
+    it 'is started' do
+      expect(subject).to be_started
     end
 
     context 'when resume is called again' do
@@ -151,7 +151,7 @@ RSpec.describe Listen::Event::Loop do
 
       allow(thread).to receive(:wakeup)
 
-      subject.setup
+      subject.start
 
       allow(subject).to receive(:sleep).with(no_args) do
         allow(processor).to receive(:loop_for).with(1.234)

--- a/spec/lib/listen/event/loop_spec.rb
+++ b/spec/lib/listen/event/loop_spec.rb
@@ -130,9 +130,7 @@ RSpec.describe Listen::Event::Loop do
 
     describe '#teardown' do
       before do
-        allow(reasons).to receive(:<<)
         allow(thread).to receive(:join)
-        expect(thread).to receive(:wakeup)
       end
 
       it 'frees the thread' do
@@ -145,7 +143,6 @@ RSpec.describe Listen::Event::Loop do
       end
 
       it 'sets the reason for waking up' do
-        expect(reasons).to receive(:<<).with(:teardown)
         subject.teardown
       end
     end

--- a/spec/lib/listen/event/processor_spec.rb
+++ b/spec/lib/listen/event/processor_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Listen::Event::Processor do
             it 'sleeps for latency to possibly later optimize some events' do
               # pretend we were woken up at 0.6 seconds since start
               allow(config).to receive(:sleep).
-                with(no_args) { |*_args| state[:time] += 0.6 }
+                with(anything) { |*_args| state[:time] += 0.6 }
 
               # pretend we slept for latency (now: 1.6 seconds since start)
               allow(config).to receive(:sleep).
@@ -130,7 +130,7 @@ RSpec.describe Listen::Event::Processor do
             it 'still does not process events because it is paused' do
               # pretend we were woken up at 0.6 seconds since start
               allow(config).to receive(:sleep).
-                with(1) { |*_args| state[:time] += 2.0 }
+                with(anything) { |*_args| state[:time] += 2.0 }
 
               # second loop starts here (no sleep, coz recent events, but no
               # processing coz paused

--- a/spec/lib/listen/event/processor_spec.rb
+++ b/spec/lib/listen/event/processor_spec.rb
@@ -4,7 +4,8 @@ require 'listen/event/config'
 RSpec.describe Listen::Event::Processor do
   let(:event_queue) { instance_double(::Queue, 'event_queue') }
   let(:event) { instance_double(::Array, 'event') }
-  let(:config) { instance_double(Listen::Event::Config) }
+  let(:listener) { instance_double(Listen::Listener, 'listener') }
+  let(:config) { instance_double(Listen::Event::Config, listener: listener) }
   let(:reasons) { instance_double(::Queue, 'reasons') }
 
   subject { described_class.new(config, reasons) }
@@ -28,11 +29,11 @@ RSpec.describe Listen::Event::Processor do
   before do
     allow(config).to receive(:event_queue).and_return(event_queue)
 
-    allow(config).to receive(:stopped?) do
+    allow(listener).to receive(:stopped?) do
       status_for_time(state[:time]) == :stopped
     end
 
-    allow(config).to receive(:paused?) do
+    allow(listener).to receive(:paused?) do
       status_for_time(state[:time]) == :paused
     end
 

--- a/spec/lib/listen/event/processor_spec.rb
+++ b/spec/lib/listen/event/processor_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe Listen::Event::Processor do
 
               # pretend we were woken up at 3.6 seconds since start
               allow(listener).to receive(:wait_for_state).
-                with(:processing_events, :stopped) do |*_args|
+                with(:initializing, :backend_started, :processing_events, :stopped) do |*_args|
                   state[:time] += 3.0
                   raise ScriptError, 'done'
                 end
@@ -210,7 +210,7 @@ RSpec.describe Listen::Event::Processor do
               end
 
               allow(listener).to receive(:wait_for_state).
-                with(:processing_events, :stopped)
+                with(:initializing, :backend_started, :processing_events, :stopped)
 
               subject.instance_variable_set(:@first_unprocessed_event_time, -3)
               subject.loop_for(1)

--- a/spec/lib/listen/event/queue_spec.rb
+++ b/spec/lib/listen/event/queue_spec.rb
@@ -8,9 +8,7 @@ RSpec.describe Listen::Event::Queue do
 
   let(:relative) { false }
 
-  let(:block) { proc {} }
-
-  subject { described_class.new(config, &block) }
+  subject { described_class.new(config) }
 
   before do
     allow(config).to receive(:relative?).and_return(relative)
@@ -54,26 +52,6 @@ RSpec.describe Listen::Event::Queue do
     let(:watched_dir) { fake_path('watched_dir') }
     before do
       allow(queue).to receive(:<<)
-    end
-
-    context 'when a block is given' do
-      let(:calls) { [] }
-      let(:block) { proc { calls << 'called!' } }
-
-      it 'calls the provided block' do
-        subject.<<([:file, :modified, watched_dir, 'foo', {}])
-        expect(calls).to eq(['called!'])
-      end
-    end
-
-    context 'when no block is given' do
-      let(:calls) { [] }
-      let(:block) { nil }
-
-      it 'calls the provided block' do
-        subject.<<([:file, :modified, watched_dir, 'foo', {}])
-        expect(calls).to eq([])
-      end
     end
 
     context 'when relative option is true' do

--- a/spec/lib/listen/listener_spec.rb
+++ b/spec/lib/listen/listener_spec.rb
@@ -146,7 +146,6 @@ RSpec.describe Listener do
 
       it 'terminates' do
         allow(backend).to receive(:stop)
-        allow(processor).to receive(:teardown)
         subject.stop
       end
     end
@@ -158,7 +157,6 @@ RSpec.describe Listener do
 
       it 'terminates' do
         allow(backend).to receive(:stop)
-        allow(processor).to receive(:teardown)
         subject.stop
       end
     end

--- a/spec/lib/listen/listener_spec.rb
+++ b/spec/lib/listen/listener_spec.rb
@@ -146,6 +146,7 @@ RSpec.describe Listener do
 
       it 'terminates' do
         allow(backend).to receive(:stop)
+        allow(processor).to receive(:teardown)
         subject.stop
       end
     end
@@ -157,6 +158,7 @@ RSpec.describe Listener do
 
       it 'terminates' do
         allow(backend).to receive(:stop)
+        allow(processor).to receive(:teardown)
         subject.stop
       end
     end

--- a/spec/lib/listen/listener_spec.rb
+++ b/spec/lib/listen/listener_spec.rb
@@ -121,16 +121,14 @@ RSpec.describe Listener do
     end
 
     it 'sets paused to false' do
-      allow(processor).to receive(:setup)
-      allow(processor).to receive(:resume)
+      allow(processor).to receive(:start)
       subject.start
       expect(subject).to_not be_paused
     end
 
     it 'starts adapter' do
       expect(backend).to receive(:start)
-      allow(processor).to receive(:setup)
-      allow(processor).to receive(:resume)
+      allow(processor).to receive(:start)
       subject.start
     end
   end
@@ -138,38 +136,12 @@ RSpec.describe Listener do
   describe '#stop' do
     before do
       allow(backend).to receive(:start)
-      allow(processor).to receive(:setup)
-      allow(processor).to receive(:resume)
+      allow(processor).to receive(:start)
     end
 
     context 'when fully started' do
       before do
         subject.start
-      end
-
-      it 'terminates' do
-        allow(backend).to receive(:stop)
-        allow(processor).to receive(:teardown)
-        subject.stop
-      end
-    end
-
-    context 'when frontend is ready' do
-      before do
-        subject.transition :backend_started
-        subject.transition :frontend_ready
-      end
-
-      it 'terminates' do
-        allow(backend).to receive(:stop)
-        allow(processor).to receive(:teardown)
-        subject.stop
-      end
-    end
-
-    context 'when only backend is already started' do
-      before do
-        subject.transition :backend_started
       end
 
       it 'terminates' do
@@ -195,8 +167,7 @@ RSpec.describe Listener do
   describe '#pause' do
     before do
       allow(backend).to receive(:start)
-      allow(processor).to receive(:setup)
-      allow(processor).to receive(:resume)
+      allow(processor).to receive(:start)
       subject.start
     end
     it 'sets paused to true' do
@@ -209,8 +180,7 @@ RSpec.describe Listener do
   describe 'unpause with start' do
     before do
       allow(backend).to receive(:start)
-      allow(processor).to receive(:setup)
-      allow(processor).to receive(:resume)
+      allow(processor).to receive(:start)
       subject.start
       allow(processor).to receive(:pause)
       subject.pause
@@ -225,8 +195,7 @@ RSpec.describe Listener do
   describe '#paused?' do
     before do
       allow(backend).to receive(:start)
-      allow(processor).to receive(:setup)
-      allow(processor).to receive(:resume)
+      allow(processor).to receive(:start)
       subject.start
     end
 
@@ -245,8 +214,7 @@ RSpec.describe Listener do
     context 'when processing' do
       before do
         allow(backend).to receive(:start)
-        allow(processor).to receive(:setup)
-        allow(processor).to receive(:resume)
+        allow(processor).to receive(:start)
         subject.start
       end
       it { should be_processing }
@@ -259,8 +227,7 @@ RSpec.describe Listener do
     context 'when paused' do
       before do
         allow(backend).to receive(:start)
-        allow(processor).to receive(:setup)
-        allow(processor).to receive(:resume)
+        allow(processor).to receive(:start)
         subject.start
         allow(processor).to receive(:pause)
         subject.pause

--- a/spec/lib/listen/listener_spec.rb
+++ b/spec/lib/listen/listener_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe Listener do
 
       it 'terminates' do
         allow(backend).to receive(:stop)
-        allow(processor).to receive(:teardown)
+        allow(processor).to receive(:stop)
         subject.stop
       end
     end
@@ -158,7 +158,7 @@ RSpec.describe Listener do
 
       it 'terminates' do
         allow(backend).to receive(:stop)
-        allow(processor).to receive(:teardown)
+        allow(processor).to receive(:stop)
         subject.stop
       end
     end

--- a/spec/lib/listen/queue_optimizer_spec.rb
+++ b/spec/lib/listen/queue_optimizer_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Listen::QueueOptimizer do
       it { is_expected.to eq(modified: ['foo'], added: [], removed: []) }
     end
 
-    context 'with a deteted temp file' do
+    context 'with a detected temp file' do
       before { allow(config).to receive(:exist?).with(foo).and_return(false) }
 
       let(:changes) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,7 @@ if ci?
   Coveralls.wear!
 end
 
-Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
+Dir["#{__dir__}/support/**/*.rb"].each { |f| require f }
 
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|

--- a/spec/support/acceptance_helper.rb
+++ b/spec/support/acceptance_helper.rb
@@ -12,23 +12,20 @@
       # 2. keep the queue if we're testing for existing accumulated changes
 
       # if were testing the queue (e.g. after unpause), don't reset
-      check_already_queued = /queued_/ =~ description
-      reset_queue = !check_already_queued
+      reset_queue = /queued_/ !~ description
 
       actual.listen(reset_queue) do
-        change_fs(type, expected) unless check_already_queued
+        change_fs(type, expected) if reset_queue
       end
       actual.changes[type].include? expected
     end
 
     failure_message do |actual|
-      result = actual.changes.inspect
-      "expected #{result} to include #{description} of #{expected}"
+      "expected #{actual.changes.inspect} to include #{description} of #{expected}"
     end
 
     failure_message_when_negated do |actual|
-      result = actual.changes.inspect
-      "expected #{result} to not include #{description} of #{expected}"
+      "expected #{actual.changes.inspect} to not include #{description} of #{expected}"
     end
   end
 end

--- a/spec/support/acceptance_helper.rb
+++ b/spec/support/acceptance_helper.rb
@@ -224,8 +224,7 @@ class ListenerWrapper
     change_offset = @timed_changes.change_offset
     freeze_offset = @timed_changes.freeze_offset
 
-    msg = "Changes took #{change_offset}s (allowed lag: #{freeze_offset})s"
-    abort(msg)
+    raise "Changes took #{change_offset}s (allowed lag: #{freeze_offset})s"
   end
 
   def _relative_path(changes)


### PR DESCRIPTION
https://ringrevenue.atlassian.net/browse/TECH-4677

The big change here is I removed code that called `sleep()` and `Thread#wakeup`. That was a race condition bug since if `wakeup` ran before `sleep()`, it will be lost and the sleeping thread will hang there.

Detailed changes:
- Use ::Mutex/::ConditionVariable to wait/wake up on state transitions. I factored this down into `FSM` since it's used twice.
- Clean up and simplify `FSM`. Enforce symbol contracts, remove unnecessary methods, rename `default_state` to `start_state` since the latter is standard FSM terminology.
- Use `Queue#pop` to block front-end when waiting for events.
- Combine `Loop#setup` and `Loop#resume` since they were always called consecutively. This allowed the `Listener` `:front_end_ready` state to disappear.
- Remove `resume` and `pause` since they were no-ops.
- Rename `teardown` to `stop` to be consistent. (I'd like to do a similar thing with `processing_events`. This should simply be called `started`.)

BTW to run `rake` on a Mac, I found I needed to tune the lag that's tolerated up to 0.8 seconds:
```
LISTEN_TESTS_DEFAULT_LAG=0.8 bundle exec rake
```
Note: I had this in the ticket:

> Maybe add internal logging of state transitions that can be dumped later if a watchdog thread finds a problem.

I didn't bother implementing that, since the bug was very clear. And the biggest mystery that led me to want the above was the missing logging. I tracked that down not having `debug` logging enabled when Listen starts up. That is now fixed on the corresponding `web` branch, by having `debug` logging enabled by default first, then tuned with process_settings once that is initialized.